### PR TITLE
feat: ScraperController 테스트 및 null 응답 처리 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
 
 	// --- 테스트 의존성 정리 ---
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/io/reco/collector/application/api/ScraperController.java
+++ b/src/main/java/io/reco/collector/application/api/ScraperController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -99,17 +100,17 @@ public class ScraperController {
         }
 
         CrawlCheckpoint cp = latest.get();
-        return ResponseEntity.ok(Map.of(
-                "runId", cp.getCrawlRunId(),
-                "type", cp.getCrawlType().name(),
-                "status", cp.getStatus().name(),
-                "lastPage", cp.getLastPage(),
-                "lastNoticeNo", cp.getLastNoticeNo(),
-                "totalCollected", cp.getTotalCollected(),
-                "totalFailed", cp.getTotalFailed(),
-                "startedAt", toIso(cp.getStartedAt()),
-                "completedAt", toIso(cp.getCompletedAt())
-        ));
+        Map<String, Object> response = new HashMap<>();
+        response.put("runId", cp.getCrawlRunId());
+        response.put("type", cp.getCrawlType().name());
+        response.put("status", cp.getStatus().name());
+        response.put("lastPage", cp.getLastPage());
+        response.put("lastNoticeNo", cp.getLastNoticeNo());
+        response.put("totalCollected", cp.getTotalCollected());
+        response.put("totalFailed", cp.getTotalFailed());
+        response.put("startedAt", toIso(cp.getStartedAt()));
+        response.put("completedAt", toIso(cp.getCompletedAt()));
+        return ResponseEntity.ok(response);
     }
 
     private String toIso(LocalDateTime t) {

--- a/src/test/java/io/reco/collector/application/api/ScraperControllerTest.java
+++ b/src/test/java/io/reco/collector/application/api/ScraperControllerTest.java
@@ -1,0 +1,157 @@
+package io.reco.collector.application.api;
+
+import io.reco.collector.domain.checkpoint.entity.CrawlCheckpoint;
+import io.reco.collector.domain.checkpoint.enums.CrawlStatus;
+import io.reco.collector.domain.checkpoint.enums.CrawlType;
+import io.reco.collector.domain.checkpoint.service.CheckpointService;
+import io.reco.collector.infrastructure.crawler.ScraperService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * ScraperController 단위 테스트
+ *
+ * Spring Boot 4.x 테스트 구조:
+ * - @SpringBootTest + @AutoConfigureMockMvc 조합 사용
+ * - @MockitoBean으로 의존성 모킹
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class ScraperControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ScraperService scraperService;
+
+    @MockitoBean
+    private CheckpointService checkpointService;
+
+    @Test
+    @DisplayName("POST /start - 크롤링 시작 성공 (비동기)")
+    void 크롤링_시작_성공() throws Exception {
+        // given
+        when(checkpointService.hasRunningCrawl()).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(post("/api/scrape/start")
+                        .param("type", "INCREMENTAL")
+                        .param("async", "true"))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.message").value("크롤링 시작"))
+                .andExpect(jsonPath("$.type").value("INCREMENTAL"));
+    }
+
+    @Test
+    @DisplayName("POST /start - 이미 실행 중이면 409 응답")
+    void 이미_실행중이면_409_응답() throws Exception {
+        // given
+        when(checkpointService.hasRunningCrawl()).thenReturn(true);
+
+        // when & then
+        mockMvc.perform(post("/api/scrape/start"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.message").value("이미 실행 중인 크롤링이 있습니다."));
+    }
+
+    @Test
+    @DisplayName("POST /start - FULL 타입 크롤링")
+    void FULL_타입_크롤링() throws Exception {
+        // given
+        when(checkpointService.hasRunningCrawl()).thenReturn(false);
+
+        // when & then
+        mockMvc.perform(post("/api/scrape/start")
+                        .param("type", "FULL"))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.type").value("FULL"));
+    }
+
+    @Test
+    @DisplayName("POST /stop - 크롤링 중지 성공")
+    void 크롤링_중지_성공() throws Exception {
+        // given
+        CrawlCheckpoint checkpoint = createCheckpoint(CrawlStatus.RUNNING);
+        when(checkpointService.getLatest()).thenReturn(Optional.of(checkpoint));
+
+        // when & then
+        mockMvc.perform(post("/api/scrape/stop"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("중지 요청됨"))
+                .andExpect(jsonPath("$.runId").value("crawl_test_001"));
+
+        verify(scraperService).requestStop();
+        verify(checkpointService).stopCrawl("crawl_test_001");
+    }
+
+    @Test
+    @DisplayName("POST /stop - 크롤링 내역 없으면 404")
+    void 크롤링_내역_없으면_404() throws Exception {
+        // given
+        when(checkpointService.getLatest()).thenReturn(Optional.empty());
+
+        // when & then
+        mockMvc.perform(post("/api/scrape/stop"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("최근 크롤링 내역이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("GET /status - 상태 조회 성공")
+    void 상태_조회_성공() throws Exception {
+        // given
+        CrawlCheckpoint checkpoint = createCheckpoint(CrawlStatus.RUNNING);
+        when(checkpointService.getLatest()).thenReturn(Optional.of(checkpoint));
+
+        // when & then
+        mockMvc.perform(get("/api/scrape/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runId").value("crawl_test_001"))
+                .andExpect(jsonPath("$.type").value("INCREMENTAL"))
+                .andExpect(jsonPath("$.status").value("RUNNING"))
+                .andExpect(jsonPath("$.lastPage").value(5))
+                .andExpect(jsonPath("$.totalCollected").value(42))
+                .andExpect(jsonPath("$.totalFailed").value(3));
+    }
+
+    @Test
+    @DisplayName("GET /status - 기록 없으면 메시지 반환")
+    void 기록_없으면_메시지_반환() throws Exception {
+        // given
+        when(checkpointService.getLatest()).thenReturn(Optional.empty());
+
+        // when & then
+        mockMvc.perform(get("/api/scrape/status"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("기록 없음"));
+    }
+
+    // === Helper ===
+
+    private CrawlCheckpoint createCheckpoint(CrawlStatus status) {
+        return CrawlCheckpoint.builder()
+                .id(1L)
+                .crawlRunId("crawl_test_001")
+                .crawlType(CrawlType.INCREMENTAL)
+                .status(status)
+                .lastPage(5)
+                .lastNoticeNo("BID-2024-001")
+                .totalCollected(42)
+                .totalFailed(3)
+                .startedAt(LocalDateTime.now().minusHours(1))
+                .build();
+    }
+}


### PR DESCRIPTION
   ## Summary
  - ScraperController에 대한 단위 테스트 7개 추가
  - `/status` 엔드포인트의 null 값 응답 처리 버그 수정 (Map.of → HashMap)
  - Spring Boot 4.x 테스트 구조 적용 (@MockitoBean, webmvc-test)

  ## Test plan
  - [x] POST /start - 크롤링 시작 성공 (비동기)
  - [x] POST /start - 이미 실행 중이면 409 응답
  - [x] POST /start - FULL 타입 크롤링
  - [x] POST /stop - 크롤링 중지 성공
  - [x] POST /stop - 크롤링 내역 없으면 404
  - [x] GET /status - 상태 조회 성공
  - [x] GET /status - 기록 없으면 메시지 반환
<br>
<img width="400" height="259" alt="image" src="https://github.com/user-attachments/assets/726d1697-a986-4e1e-bae4-f8cdd122c008" />
